### PR TITLE
Fix sonar code smell - missing break

### DIFF
--- a/src/common/helper/blockfilereader.cpp
+++ b/src/common/helper/blockfilereader.cpp
@@ -133,6 +133,7 @@ bool BlockFileReader::lseek(int position, int whence)
         break;
     case SEEK_SET:
         offset = position + m_seek;
+        break;
     default:
         break;
     }


### PR DESCRIPTION
It is not an error, because it is last case before default case. But it is recognized as code smell by sonarcloud (https://sonarcloud.io/project/issues?id=adshares-ads&open=AWRzvO9kI66nRh8YG8DH&resolved=false&severities=BLOCKER&types=CODE_SMELL) and can be source of bug in the future.